### PR TITLE
Support cutout and rounded corners

### DIFF
--- a/app/src/main/java/com/nagopy/android/overlaybatterybar/App.kt
+++ b/app/src/main/java/com/nagopy/android/overlaybatterybar/App.kt
@@ -4,11 +4,13 @@ import android.app.Application
 import android.app.NotificationManager
 import android.content.Context
 import android.content.SharedPreferences
+import android.hardware.display.DisplayManager
 import android.os.BatteryManager
 import android.os.Handler
 import android.os.Looper
 import android.os.PowerManager
 import android.preference.PreferenceManager
+import android.view.WindowManager
 import com.nagopy.android.overlayviewmanager.OverlayViewManager
 import org.kodein.di.*
 import timber.log.Timber
@@ -37,7 +39,12 @@ class App : Application(), DIAware {
         }
         bind<MainService.Handler>() with singleton { MainService.Handler(instance()) }
         bind<BatteryBarDelegate>() with singleton {
-            BatteryBarDelegate(instance(), instance(), instance(), instance(), instance())
+            BatteryBarDelegate(instance(), instance(), instance(), instance(), instance(), instance())
+        }
+        bind<WindowManager>() with singleton { instance<Context>().getSystemService(WINDOW_SERVICE) as WindowManager }
+        bind<DisplayManager>() with singleton { instance<Context>().getSystemService(DISPLAY_SERVICE) as DisplayManager }
+        bind<DisplaySize>() with singleton {
+            DisplaySize(instance(), instance())
         }
     }
 }

--- a/app/src/main/java/com/nagopy/android/overlaybatterybar/DisplaySize.kt
+++ b/app/src/main/java/com/nagopy/android/overlaybatterybar/DisplaySize.kt
@@ -1,0 +1,86 @@
+package com.nagopy.android.overlaybatterybar
+
+import android.graphics.Insets
+import android.hardware.display.DisplayManager
+import android.os.Build
+import android.util.DisplayMetrics
+import android.view.Display
+import android.view.RoundedCorner
+import android.view.WindowInsets
+import android.view.WindowManager
+import androidx.annotation.VisibleForTesting
+
+class DisplaySize(
+    private val windowManager: WindowManager
+    , private val displayManager: DisplayManager
+) {
+    
+    data class Result(
+        val displayWidth: Int,
+        val roundedCornerRadius: Int,
+        val cutoutWidth: Int,
+        val isCutoutLeft: Boolean,
+    )
+    
+    fun calc(): Result {
+        val displayWidth = getDisplayWidth()
+        val roundedCornerRadius = getRoundedCorner()
+        val cutoutInsets = getCutoutInsets()
+        val cutoutWidth = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            (cutoutInsets?.right ?: 0) + (cutoutInsets?.left ?: 0)
+        } else {
+            0
+        }
+        val isCutoutLeft = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            (cutoutInsets?.left ?: 0) > 0
+        } else {
+            false
+        }
+
+        return Result(displayWidth, roundedCornerRadius, cutoutWidth, isCutoutLeft)
+    }
+
+    @VisibleForTesting
+    fun getRoundedCorner(): Int {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val display = displayManager.getDisplay(Display.DEFAULT_DISPLAY)
+            val roundedCorner = display?.getRoundedCorner(RoundedCorner.POSITION_TOP_RIGHT)
+            return roundedCorner?.radius?.toInt() ?: 0
+        } else {
+            return 0
+        }
+    }
+
+    @VisibleForTesting
+    fun getCutoutInsets(): Insets? {
+        when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> {
+                val metrics = windowManager.currentWindowMetrics
+
+                // ノッチが上下にある場合はright, leftが0になる
+                // ノッチが左右にある場合はrightかleftに幅が入る
+                val insets = metrics.windowInsets.getInsetsIgnoringVisibility(WindowInsets.Type.displayCutout())
+                return insets
+            }
+            else -> {
+                return null
+            }
+        }
+    }
+
+    @VisibleForTesting
+    fun getDisplayWidth(): Int {
+        when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> {
+                val metrics = windowManager.currentWindowMetrics
+                return metrics.bounds.width()
+            }
+            else -> {
+                val displayMetrics = DisplayMetrics()
+                windowManager.defaultDisplay.getMetrics(displayMetrics)
+                return displayMetrics.widthPixels
+            }
+        }
+    }
+
+}

--- a/app/src/test/java/com/nagopy/android/overlaybatterybar/DisplaySizeTest.kt
+++ b/app/src/test/java/com/nagopy/android/overlaybatterybar/DisplaySizeTest.kt
@@ -1,0 +1,86 @@
+package com.nagopy.android.overlaybatterybar
+
+import android.graphics.Insets
+import android.graphics.Rect
+import android.hardware.display.DisplayManager
+import android.os.Build
+import android.util.DisplayMetrics
+import android.view.Display
+import android.view.RoundedCorner
+import android.view.WindowInsets
+import android.view.WindowManager
+import android.view.WindowMetrics
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+class DisplaySizeTest {
+
+    @Mock
+    lateinit var windowManager: WindowManager
+    @Mock
+    lateinit var displayManager: DisplayManager
+
+    lateinit var displaySize: DisplaySize
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        displaySize = DisplaySize(windowManager, displayManager)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.R])
+    fun test_getRoundedCornerApi30() {
+        assertThat(displaySize.getRoundedCorner(), `is`(0))
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.S])
+    fun test_getRoundedCornerApi31() {
+        val display = mock(Display::class.java)
+        val roundedCorner = mock(RoundedCorner::class.java)
+        `when`(displayManager.getDisplay(Display.DEFAULT_DISPLAY)).thenReturn(display)
+        `when`(display.getRoundedCorner(RoundedCorner.POSITION_TOP_RIGHT)).thenReturn(roundedCorner)
+        `when`(roundedCorner.radius).thenReturn(10)
+        assertThat(displaySize.getRoundedCorner(), `is`(10))
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.R])
+    fun test_getDisplayWidthApi30() {
+        val metrics = mock(WindowMetrics::class.java)
+        `when`(windowManager.currentWindowMetrics).thenReturn(metrics)
+        val windowInsets = mock(WindowInsets::class.java)
+        `when`(metrics.windowInsets).thenReturn(windowInsets)
+        val bounds = mock(Rect::class.java)
+        `when`(metrics.bounds).thenReturn(bounds)
+        `when`(bounds.width()).thenReturn(1000)
+        assertThat(displaySize.getDisplayWidth(), `is`(1000))
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.Q])
+    fun test_getDisplayWidthApi29() {
+        val display = mock(Display::class.java)
+        `when`(windowManager.defaultDisplay).thenReturn(display)
+        `when`(display.getMetrics(any())).thenAnswer {
+            val displayMetrics = it.arguments[0] as DisplayMetrics
+            displayMetrics.widthPixels = 100
+        }
+        assertThat(displaySize.getDisplayWidth(), `is`(100))
+        verify(display, times(1)).getMetrics(any())
+    }
+}


### PR DESCRIPTION
Add DisplaySize utility and refactor BatteryBarDelegate to support cutout and rounded corners.

- Introduced `DisplaySize` class to encapsulate logic for obtaining display width, rounded corner radius, and cutout information.
- Updated `BatteryBarDelegate` to account for rounded corners and cutouts when calculating battery bar position and width.
- Modified `BatteryBarDelegate` constructor to include `DisplaySize` as a dependency.
- Added detailed logging for battery bar position and width calculation.
- Updated tests for `BatteryBarDelegate` to validate new behavior and added comprehensive test cases for `DisplaySize`.

This change improves compatibility with devices featuring cutouts and rounded corners while ensuring accurate rendering of the battery bar.